### PR TITLE
Add a border to JLabels

### DIFF
--- a/src/main/java/com/clanevents/ClanEventsPanel.java
+++ b/src/main/java/com/clanevents/ClanEventsPanel.java
@@ -298,6 +298,7 @@ class ClanEventsPanel extends PluginPanel
 
                 j = 0;
                 for (List<Object> lst : values) {
+                    //noinspection SuspiciousToArrayCall
                     rows[j++] = lst.toArray(new String[0]);
                 }
 
@@ -740,6 +741,7 @@ class ClanEventsPanel extends PluginPanel
                             panel = new JPanel(new BorderLayout());
                             panel.setBorder(new EmptyBorder(0, 0, 3, 0));
                             JLabel label = new JLabel("<html>");
+                            label.setBorder(new EmptyBorder(3, 3, 3, 3));
 
                             newLine = "";
                             addNewline = false;


### PR DESCRIPTION
Add a small border to JLabels so that they fit within their panels. Also suppress last warning in ClanEventsPanel seeing as there's no obvious way to fix it.