### PR TITLE
Config and QoL updates

### DIFF
--- a/src/main/java/com/clanevents/ClanEventsConfig.java
+++ b/src/main/java/com/clanevents/ClanEventsConfig.java
@@ -1,25 +1,27 @@
 package com.clanevents;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.*;
 
 import java.awt.*;
 
 @ConfigGroup(ClanEventsPlugin.CONFIG_GROUP)
 public interface ClanEventsConfig extends Config
 {
+	int TIMEOUT_MIN = 1;
+	int TIMEOUT_MAX = 10;
+	int REFRESH_PERIOD_MIN = 5;
+	int REFRESH_PERIOD_MAX = 1440;
+
 	@ConfigSection(
-			name = "Event Password",
-			description = "Password info for clan event",
+			name = "Overlay",
+			description = "Overlay configuration.",
 			position = 0
 	)
-	String eventPassSection = "Event Passphrase";
+	String overlaySection = "Event Passphrase";
 
 	@ConfigSection(
 			name = "Google Sheets",
-			description = "Google Sheet API Config",
+			description = "Google Sheets configuration",
 			position = 1
 	)
 	String gSheetsSection = "Google Sheets API";
@@ -27,9 +29,9 @@ public interface ClanEventsConfig extends Config
 	@ConfigItem(
 			position = 1,
 			keyName = "overlay",
-			name = "Display the overlay",
-			description = "Display the overlay on your game screen",
-			section = eventPassSection
+			name = "Display Overlay",
+			description = "Displays the overlay on your game screen.",
+			section = overlaySection
 	)
 	default boolean overlay()
 	{
@@ -38,21 +40,10 @@ public interface ClanEventsConfig extends Config
 
 	@ConfigItem(
 			position = 2,
-			keyName = "eventPass",
-			name = "Event Password",
-			description = "Creates an overlay with the event password time",
-			section = eventPassSection
-	)
-	default String eventPass()
-	{
-		return "";
-	}
-	@ConfigItem(
-			position = 3,
 			keyName = "dtm",
-			name = "Include Date & Time",
-			description = "Display the date and time",
-			section = eventPassSection
+			name = "Date & Time",
+			description = "Adds the date and time to the overlay.",
+			section = overlaySection
 	)
 	default boolean dtm()
 	{
@@ -60,13 +51,25 @@ public interface ClanEventsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 4,
-			keyName = "subPass",
-			name = "Bounty/Challenge Password",
-			description = "Display the sub passsword.",
-			section = eventPassSection
+			position = 3,
+			keyName = "eventPass",
+			name = "Event Password:",
+			description = "Adds the event password to the overlay.",
+			section = overlaySection
 	)
-	default String subPass()
+	default String eventPass()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+			position = 4,
+			keyName = "challengePass",
+			name = "Challenge Password:",
+			description = "Adds the challenge password to the overlay.",
+			section = overlaySection
+	)
+	default String challengePass()
 	{
 		return "";
 	}
@@ -74,9 +77,9 @@ public interface ClanEventsConfig extends Config
 	@ConfigItem(
 			position = 5,
 			keyName = "disclaimer",
-			name = "Colors MUST be different:",
-			description = "The Password color and the Date/Time color must be different",
-			section = eventPassSection
+			name = "Colors below must be different",
+			description = "The Password Color and the Date & Time Color must be different.",
+			section = overlaySection
 	)
 	default void disclaimer() {}
 
@@ -84,8 +87,8 @@ public interface ClanEventsConfig extends Config
 			position = 6,
 			keyName = "passColor",
 			name = "Password Color",
-			description = "Configures the color of the passphrase",
-			section = eventPassSection
+			description = "The color of the Event Password and Challenge Password.",
+			section = overlaySection
 	)
 	default Color passColor()
 	{
@@ -95,9 +98,9 @@ public interface ClanEventsConfig extends Config
 	@ConfigItem(
 			position = 7,
 			keyName = "timeColor",
-			name = "Time Color",
-			description = "Configures the color of the date and time",
-			section = eventPassSection
+			name = "Date & Time Color",
+			description = "The color of the Date & Time.",
+			section = overlaySection
 	)
 	default Color timeColor()
 	{
@@ -107,25 +110,53 @@ public interface ClanEventsConfig extends Config
 	@ConfigItem(
 			position = 1,
 			keyName = "sheetId",
-			name = "Google Sheet ID (Restart plugin)",
-			description = "ID of the google sheet to read.  You may need to restart the plugin after you have changed this.",
+			name = "Google Sheet ID:",
+			description = "ID of the Google Sheet to read.",
 			section = gSheetsSection
 	)
-	default String sheetId()
-	{
-		return "1YMcXxSL3s1NEzsPVMMkPn7EdGNFKENiwqNyDKkJTO80";
-	}
+	default String sheetId() { return "1YMcXxSL3s1NEzsPVMMkPn7EdGNFKENiwqNyDKkJTO80"; }
 
 	@ConfigItem(
 			position = 2,
 			keyName = "apiKey",
-			name = "Google Sheet API Key",
-			description = "Google project API Key (ask your clan for one).  You may need to restart the plugin after you have changed this.",
+			name = "Google API Key:",
+			description = "Key used to access the Google Sheet (ask your clan for one).",
 			section = gSheetsSection
 	)
-	default String apiKey()
-	{
-		return "";
-	}
+	default String apiKey() { return ""; }
 
+	@Range(
+			min = TIMEOUT_MIN,
+			max = TIMEOUT_MAX
+	)
+	@ConfigItem(
+			position = 3,
+			keyName = "requestTimeout",
+			name = "Request Timeout (s)",
+			description = "(1-10) The Google Sheet HTTP request timeout in seconds.",
+			section = gSheetsSection
+	)
+	default int requestTimeout() { return 3; }
+
+	@ConfigItem(
+			position = 4,
+			keyName = "autoRefresh",
+			name = "Automatic Refresh",
+			description = "Enables automatic refreshing of the Clan Events panel.",
+			section = gSheetsSection
+	)
+	default boolean autoRefresh() { return false; }
+
+	@Range(
+			min = REFRESH_PERIOD_MIN,
+			max = REFRESH_PERIOD_MAX
+	)
+	@ConfigItem(
+			position = 5,
+			keyName = "refreshPeriod",
+			name = "Refresh Period (min)",
+			description = "(5-1440) How often the Automatic Refresh should occur in minutes.",
+			section = gSheetsSection
+	)
+	default int refreshPeriod() { return 10; }
 }

--- a/src/main/java/com/clanevents/ClanEventsOverlay.java
+++ b/src/main/java/com/clanevents/ClanEventsOverlay.java
@@ -1,11 +1,9 @@
 package com.clanevents;
 
-import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
-import net.runelite.client.ui.overlay.components.TitleComponent;
 import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
 
 import javax.inject.Inject;
@@ -20,25 +18,20 @@ import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
 
 public class ClanEventsOverlay extends OverlayPanel
 {
-    private final Client client;
-    private final ClanEventsPlugin plugin;
     @Inject
     private ClanEventsConfig config;
 
     @Inject
-    private ClanEventsOverlay(Client client, ClanEventsPlugin plugin)
+    private ClanEventsOverlay()
     {
-        super(plugin);
         setPosition(OverlayPosition.TOP_CENTER);
-        this.client = client;
-        this.plugin = plugin;
         getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Event overlay"));
     }
 
     @Override
     public Dimension render(Graphics2D graphics)
     {
-        String text = config.eventPass() + " " + config.subPass();
+        String text = config.eventPass() + " " + config.challengePass();
         Color passColor = config.passColor();
         Color timeColor = config.timeColor();
 
@@ -58,15 +51,11 @@ public class ClanEventsOverlay extends OverlayPanel
             {
                 text = text + " " + localToGMT();
                 List<LayoutableRenderableEntity> elem = panelComponent.getChildren();
-                ((LineComponent) elem.get(0))
-                        .setRight(localToGMT());
-                ((LineComponent) elem.get(0))
-                        .setRightColor(timeColor);
+                ((LineComponent) elem.get(0)).setRight(localToGMT());
+                ((LineComponent) elem.get(0)).setRightColor(timeColor);
             }
 
-            panelComponent.setPreferredSize(new Dimension(
-                    graphics.getFontMetrics().stringWidth(text) + 10,
-                    0));
+            panelComponent.setPreferredSize(new Dimension(graphics.getFontMetrics().stringWidth(text) + 10, 0));
         }
         return super.render(graphics);
     }

--- a/src/main/java/com/clanevents/ClanEventsPlugin.java
+++ b/src/main/java/com/clanevents/ClanEventsPlugin.java
@@ -49,21 +49,21 @@ public class ClanEventsPlugin extends Plugin
 	static final String CONFIG_GROUP = "clanevents";
 
 	@Override
-	protected void startUp() throws Exception
+	protected void startUp()
 	{
 		overlayManager.add(overlay);
 		startClanPanel();
 	}
 
 	@Override
-	protected void shutDown() throws Exception
+	protected void shutDown()
 	{
 		overlayManager.remove(overlay);
 		clientToolbar.removeNavigation(uiNavigationButton);
 	}
 
 	@Subscribe
-	private void onConfigChanged(ConfigChanged event) throws IOException {
+	private void onConfigChanged(ConfigChanged event) {
 		if (event.getGroup().equals(CONFIG_GROUP))
 		{
 			panel.removeAll();
@@ -78,7 +78,7 @@ public class ClanEventsPlugin extends Plugin
 		{
 			final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "icon.png");
 			panel = injector.getInstance(ClanEventsPanel.class);
-			panel.init(config, 0);
+			panel.init(config);
 			uiNavigationButton = NavigationButton.builder()
 					.tooltip("Clan Events")
 					.icon(icon)

--- a/src/main/java/com/clanevents/GoogleSheet.java
+++ b/src/main/java/com/clanevents/GoogleSheet.java
@@ -13,6 +13,7 @@ public class GoogleSheet {
     private static final String APPLICATION_NAME = "Google Sheets API Java Quickstart";
     private static Object API_KEY;
     private static String spreadsheetId;
+    private static int httpTimeout;
 
     public void setKey(String appKey)
     {
@@ -24,10 +25,13 @@ public class GoogleSheet {
         spreadsheetId = sheetID;
     }
 
+    public void setTimeout(int timeout) { httpTimeout = timeout; }
+
     private static Sheets getSheets() {
         NetHttpTransport transport = new NetHttpTransport.Builder().build();
         GsonFactory gsonFactory = GsonFactory.getDefaultInstance();
         HttpRequestInitializer httpRequestInitializer = request -> {
+            request.setReadTimeout(httpTimeout * 1000);
             request.setInterceptor(intercepted -> intercepted.getUrl().set("key", API_KEY));
         };
 


### PR DESCRIPTION
Updated the order of existing configuration and what gets displayed for them. Added a configuration for HTTP timeout, automatically refreshing, and the period for automatic refreshing. The Google Sheet HTTP requests will now only occur after you click on the Clan Events panel, before it was doing this every time a configuration was changed and on startup, which made the Runelite startup loading screen take a lot longer.