### PR TITLE
fix: buttons correctly open urls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 }
 
 group = 'com.clanevents'
-version = '2.1.1'
+version = '2.1.2'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'example'
+rootProject.name = 'clan-events'


### PR DESCRIPTION
buttons containing links do not open correctly on some Linux systems as the Java AWT's Desktop class does not function properly if GNOME libraries are missing. This commit adds additional attempts to open URIs when the desktop does not support the Desktop.Action.BROWSE action.

fixes cmsu224/clan-events#33